### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ install:
  - python3 setup.py develop
  - cd $var1
 
- - git clone https://github.com/enjoy-digital/litex  --recursive
+ - git clone https://github.com/enjoy-digital/litex
  - cd litex
  - python3 setup.py develop
  - cd $var1
     
 jobs:
   include:
-   - script: python -m unittest test.__init__.py
-   - script: python -m unittest test.common.py
-   - script: python -m unittest test.test_axi.py
-   - script: python -m unittest test.test_bist.py
-   - script: python -m unittest test.test_downconverter.py
-   - script: python -m unittest test.test_ecc.py
-   - script: python -m unittest test.test_examples.py
-   - script: python -m unittest test.test_upconverter.py
+   - script: python -m unittest test.__init__
+   - script: python -m unittest test.common
+   - script: python -m unittest test.test_axi
+   - script: python -m unittest test.test_bist
+   - script: python -m unittest test.test_downconverter
+   - script: python -m unittest test.test_ecc
+   - script: python -m unittest test.test_examples
+   - script: python -m unittest test.test_upconverter

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ dist: Xenial
 python: "3.7"
     
 install:
+    - cd EwoutH/litedram
     - setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 dist: Xenial
-python: "3.5"
+python: "3.7"
 
 env:
- - TEST: 'test.__init__'
- - TEST: 'test.common'
  - TEST: 'test.test_axi'
  - TEST: 'test.test_bist'
  - TEST: 'test.test_downconverter'
@@ -14,15 +12,18 @@ env:
 
 install:
  - var1="$(pwd)"
-
+## Get migen
  - git clone https://github.com/m-labs/migen
  - cd migen
  - python3 setup.py develop
  - cd $var1
-
+## Get litex
  - git clone https://github.com/enjoy-digital/litex
  - cd litex
  - python3 setup.py develop
  - cd $var1
+ ## Run common tests
+ - python -m unittest test.__init__
+ - python -m unittest test.common
     
 script: python -m unittest $TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3.7"
+    - "3.6"
     
 install:
     - setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: Xenial
 python: "3.7"
 
 install:
- - python setup.py setup
+ - setup.py setup
     
 jobs:
   include:
-   - script: python test/*.py
+   - script: test/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
  - python setup.py setup
     
 jobs:
- include:
-  - script:python test/*.py
+  include:
+   - script: python test/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: python
 dist: Xenial
 python: "3.7"
+
+    
+install:
+    - cd EwoutH/litedram
+    - setup
+    
+script: test/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,16 @@ dist: Xenial
 python: "3.7"
 
 install:
+ - export var1="$(pwd)"
+
+ - git clone https://github.com/m-labs/migen --recursive
+ - cd migen
+ - python3 setup.py develop
+ - cd var1
+
  - git clone https://github.com/enjoy-digital/litex --recursive
  - cd litex
  - python3 setup.py develop
- - cd ..
+ - cd var1
     
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
  - python3 setup.py develop
  - cd $var1
 
- - git clone https://github.com/enjoy-digital/litex
+ - git clone https://github.com/enjoy-digital/litex --recursive
  - cd litex
  - python3 setup.py develop
  - cd $var1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: python
 dist: Xenial
 python: "3.7"
 
-    
 install:
-    - cd EwoutH/litedram
-    - setup
+ - python setup.py
     
-script: test/*.py
+script:
+ - python  test/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: Xenial
 python: "3.7"
 
 install:
- - setup.py setup
+ - 
     
 jobs:
   include:
-   - script: test/*.py
+   - script: python test/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ install:
  - git clone https://github.com/m-labs/migen
  - cd migen
  - python3 setup.py develop
- - cd var1
+ - cd $var1
 
  - git clone https://github.com/enjoy-digital/litex --recursive
  - cd litex
  - python3 setup.py develop
- - cd var1
+ - cd $var1
     
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 dist: Xenial
-python: "3.7"
+python: "3.5"
 
 env:
  - TEST: 'test.__init__'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: "3.7"
 install:
  - export var1="$(pwd)"
 
- - git clone https://github.com/m-labs/migen --recursive
+ - git clone https://github.com/m-labs/migen
  - cd migen
  - python3 setup.py develop
  - cd var1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ dist: Xenial
 python: "3.7"
 
 install:
- - 
+ - git clone https://github.com/enjoy-digital/litex --recursive
+ - cd litex
+ - python3 setup.py develop
+ - cd ..
     
-jobs:
-  include:
-   - script: python test/*.py
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,16 @@ language: python
 dist: Xenial
 python: "3.7"
 
+env:
+ - TEST: 'test.__init__'
+ - TEST: 'test.common'
+ - TEST: 'test.test_axi'
+ - TEST: 'test.test_bist'
+ - TEST: 'test.test_downconverter'
+ - TEST: 'test.test_ecc'
+ - TEST: 'test.test_examples'
+ - TEST: 'test.test_upconverter'
+
 install:
  - var1="$(pwd)"
 
@@ -10,18 +20,9 @@ install:
  - python3 setup.py develop
  - cd $var1
 
- - git clone https://github.com/enjoy-digital/litex --recursive
+ - git clone https://github.com/enjoy-digital/litex
  - cd litex
  - python3 setup.py develop
  - cd $var1
     
-jobs:
-  include:
-   - script: python -m unittest test.__init__
-   - script: python -m unittest test.common
-   - script: python -m unittest test.test_axi
-   - script: python -m unittest test.test_bist
-   - script: python -m unittest test.test_downconverter
-   - script: python -m unittest test.test_ecc
-   - script: python -m unittest test.test_examples
-   - script: python -m unittest test.test_upconverter
+script: python -m unittest $TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - python3 setup.py develop
  - cd $var1
     
-jobs
+jobs:
   include:
    - script: python -m unittest test.__init__.py
    - script: python -m unittest test.common.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,13 @@ install:
  - python3 setup.py develop
  - cd $var1
     
-script: python setup.py test
+jobs
+  include:
+   - script: python -m unittest test.__init__.py
+   - script: python -m unittest test.common.py
+   - script: python -m unittest test.test_axi.py
+   - script: python -m unittest test.test_bist.py
+   - script: python -m unittest test.test_downconverter.py
+   - script: python -m unittest test.test_ecc.py
+   - script: python -m unittest test.test_examples.py
+   - script: python -m unittest test.test_upconverter.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: python
 dist: Xenial
 python: "3.7"
-    
-install:
-    - cd EwoutH/litedram
-    - setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+    - "3.7"
+    
+install:
+    - setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
  - python3 setup.py develop
  - cd $var1
 
- - git clone https://github.com/enjoy-digital/litex --recursive
+ - git clone https://github.com/enjoy-digital/litex
  - cd litex
  - python3 setup.py develop
  - cd $var1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: Xenial
 python: "3.7"
 
 install:
- - python setup.py
+ - python setup.py setup
     
-script:
- - python  test/*.py
+jobs:
+ include:
+  - script:python test/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
-python:
-    - "3.6"
+dist: Xenial
+python: "3.7"
     
 install:
     - setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: Xenial
 python: "3.7"
 
 install:
- - export var1="$(pwd)"
+ - var1="$(pwd)"
 
  - git clone https://github.com/m-labs/migen
  - cd migen

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
  - python3 setup.py develop
  - cd $var1
 
- - git clone https://github.com/enjoy-digital/litex
+ - git clone https://github.com/enjoy-digital/litex  --recursive
  - cd litex
  - python3 setup.py develop
  - cd $var1


### PR DESCRIPTION
This PR adds continuous integration with Travis. It runs the tests in the `test` directory on Ubuntu 1604 with Python 3.7.

Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) in the GitHub Marketplace.

At the moment `test.__init__`, `test.common`, `test.test_axi` and `test.test_ecc` pass, while `test.test_bist`, `test.test_downconverter`, `test.test_examples` and `test.test_upconverter` fail.